### PR TITLE
Fix build time warnings for vxs.inc

### DIFF
--- a/vutil/vxs.inc
+++ b/vutil/vxs.inc
@@ -5,7 +5,7 @@
 #  define VXS_CLASS "version"
 #  define VXSp(name) XS_##name
 /* VXSXSDP = XSUB Details Proto */
-#  define VXSXSDP(x) x
+#  define VXSXSDP(x) x, 0
 #else
 #  define VXS_CLASS "version::vxs"
 #  define VXSp(name) VXS_##name


### PR DESCRIPTION
Addresses issues identified after a recent cpan sync into blead.

See https://github.com/Perl/perl5/issues/18202